### PR TITLE
制御フローを確実に破壊する Node の移動を行わないように変更 #54

### DIFF
--- a/src/main/java/jp/kusumotolab/kgenprog/project/jdt/MoveAfterOperation.java
+++ b/src/main/java/jp/kusumotolab/kgenprog/project/jdt/MoveAfterOperation.java
@@ -32,6 +32,11 @@ public class MoveAfterOperation extends JDTOperation {
       throw new UnsupportedOperationException("cannot move parent node after child node.");
     }
 
+    if (isNotToBeMoved(src)) {
+      throw new UnsupportedOperationException(
+          "moving this node may break the control flow: " + src.toString());
+    }
+
     final ListRewrite listRewrite = astRewrite.getListRewrite(dest.getParent(),
         (ChildListPropertyDescriptor) dest.getLocationInParent());
     final ASTNode copiedSrc = ASTNode.copySubtree(astRewrite.getAST(), src);
@@ -54,5 +59,26 @@ public class MoveAfterOperation extends JDTOperation {
 
   private boolean isMethodDeclaration(final ASTNode node) {
     return node.getNodeType() == ASTNode.METHOD_DECLARATION;
+  }
+
+  private boolean isNotToBeMoved(final ASTNode node) {
+    return isBreakStatement(node) || isContinueStatement(node) || isReturnStatement(node)
+        || isThrowStatement(node);
+  }
+
+  private boolean isBreakStatement(final ASTNode node) {
+    return node.getNodeType() == ASTNode.BREAK_STATEMENT;
+  }
+
+  private boolean isContinueStatement(final ASTNode node) {
+    return node.getNodeType() == ASTNode.CONTINUE_STATEMENT;
+  }
+
+  private boolean isReturnStatement(final ASTNode node) {
+    return node.getNodeType() == ASTNode.RETURN_STATEMENT;
+  }
+
+  private boolean isThrowStatement(final ASTNode node) {
+    return node.getNodeType() == ASTNode.THROW_STATEMENT;
   }
 }


### PR DESCRIPTION
resolve #54 

以下の Node は移動しない
- break 文
- continue 文
- return 文
- throw 文